### PR TITLE
Fix ESPP report, some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for the tax year.
 
 # Obtaining Schwab CSV export for last year
 
-1.  Go to "History" tab.
+1.  Go to "Transaction History" tab.
 
 2.  Choose "Equity Award Center" from the dropdown.
 

--- a/src/main/java/cz/solutions/cockroach/EsppReportPreparation.java
+++ b/src/main/java/cz/solutions/cockroach/EsppReportPreparation.java
@@ -31,7 +31,7 @@ public class EsppReportPreparation {
         ArrayList<PrintableEspp> printableEsppList = new ArrayList<>();
         double profitDolarValue = 0;
         double profitCroneValue = 0;
-        double taxablePofitCroneValue = 0;
+        double taxableProfitCroneValue = 0;
         int totalEsppAmount = 0;
 
         for (EsppRecord espp : esppRecords) {
@@ -45,10 +45,10 @@ public class EsppReportPreparation {
 
             printableEsppList.add(esppInfo.toPrintable());
             profitDolarValue += esppInfo.getBuyProfitValue();
-            profitCroneValue += esppInfo.getBuyCronePofitValue();
+            profitCroneValue += esppInfo.getBuyCroneProfitValue();
 
             totalEsppAmount += espp.getQuantity();
-            taxablePofitCroneValue+=esppInfo.getTaxableBuyCronePofitValue();
+            taxableProfitCroneValue +=esppInfo.getTaxableBuyCroneProfitValue();
         }
 
         return new EsppReport(
@@ -56,7 +56,7 @@ public class EsppReportPreparation {
                 profitCroneValue,
                 profitDolarValue,
                 totalEsppAmount,
-                taxablePofitCroneValue
+                taxableProfitCroneValue
         );
     }
 
@@ -87,9 +87,9 @@ public class EsppReportPreparation {
             double onePriceDolarValue;
             double oneProfitValue;
             double buyProfitValue;
-            double buyCronePofitValue;
+            double buyCroneProfitValue;
             double soldAmount;
-            double taxableBuyCronePofitValue;
+            double taxableBuyCroneProfitValue;
 
             PrintableEspp toPrintable() {
                 return new PrintableEspp(
@@ -100,9 +100,9 @@ public class EsppReportPreparation {
                         FormatingHelper.formatDouble(onePriceDolarValue),
                         FormatingHelper.formatDouble(oneProfitValue),
                         FormatingHelper.formatDouble(buyProfitValue),
-                        FormatingHelper.formatDouble(buyCronePofitValue),
+                        FormatingHelper.formatDouble(buyCroneProfitValue),
                         soldAmount,
-                        FormatingHelper.formatDouble(taxableBuyCronePofitValue)
+                        FormatingHelper.formatDouble(taxableBuyCroneProfitValue)
                 );
             }
         }

--- a/src/main/java/cz/solutions/cockroach/EsppReportPreparation.java
+++ b/src/main/java/cz/solutions/cockroach/EsppReportPreparation.java
@@ -10,7 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class EsppReportPreparation {
-    private static final DateTimeFormatter DATE_FORMATTERTER = DateTimeFormat.forPattern("dd.MM.YYYY").withZoneUTC();
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("dd.MM.YYYY").withZoneUTC();
 
     public EsppReport generateEsppReport(List<EsppRecord> esppRecordList,
                                          List<SaleRecord> saleRecordList,
@@ -93,13 +93,13 @@ public class EsppReportPreparation {
 
             PrintableEspp toPrintable() {
                 return new PrintableEspp(
-                        DATE_FORMATTERTER.print(date),
+                        DATE_FORMATTER.print(date),
                         amount,
                         FormatingHelper.formatExchangeRate(exchange),
                         FormatingHelper.formatDouble(onePricePurchaseDolarValue),
                         FormatingHelper.formatDouble(onePriceDolarValue),
                         FormatingHelper.formatDouble(oneProfitValue),
-                        FormatingHelper.formatDouble(buyCronePofitValue),
+                        FormatingHelper.formatDouble(buyProfitValue),
                         FormatingHelper.formatDouble(buyCronePofitValue),
                         soldAmount,
                         FormatingHelper.formatDouble(taxableBuyCronePofitValue)

--- a/src/main/java/cz/solutions/cockroach/PrintableEspp.java
+++ b/src/main/java/cz/solutions/cockroach/PrintableEspp.java
@@ -11,7 +11,7 @@ public class PrintableEspp {
     String onePriceDolarValue;
     String oneProfitValue;
     String buyProfitValue;
-    String buyCronePofitValue;
+    String buyCroneProfitValue;
     double soldAmount;
     String taxableBuyCroneProfitValue;
 }

--- a/src/main/resources/cz/solutions/cockroach/espp.hbs
+++ b/src/main/resources/cz/solutions/cockroach/espp.hbs
@@ -11,6 +11,6 @@ Obchodník s cennými papíry: Charles Schwab & Co.
 | datum nákupu  |      počet akcií    | zvýhodněná nákupní cena (USD) | tržní cena (USD) | zisk (USD)| kurz D54 (Kč/USD) | zisk (Kč) | prodáno v akt. období  | zdanitelný zisk v akt. období (Kč)
 |----------|:-------------:|------:|------:|------:|------:|------:|------:|------:|
 {{#each esppList}}
-|{{this.date}}|{{this.amount}}|{{this.onePricePurchaseDolarValue}}| {{this.onePriceDolarValue}}|{{this.buyProfitValue}}|{{this.exchange}}| {{this.buyCronePofitValue}}| {{this.soldAmount}}|{{this.taxableBuyCroneProfitValue}}|
+|{{this.date}}|{{this.amount}}|{{this.onePricePurchaseDolarValue}}| {{this.onePriceDolarValue}}|{{this.buyProfitValue}}|{{this.exchange}}| {{this.buyCroneProfitValue}}| {{this.soldAmount}}|{{this.taxableBuyCroneProfitValue}}|
 {{/each}}
 | celkem   |  **{{totalAmount}}**    |    |  | **{{profitDolarValue}}** | |**{{profitCroneValue}}** ||**{{taxableProfitCroneValue}}**|


### PR DESCRIPTION
- **ESPP report showed CZK value in USD column**
- **Fix a typo by s/pofit/profit; update Schwab website navigation update**
