### PR TITLE
Ignore reinvestments in e-trade dividends

### DIFF
--- a/src/main/kotlin/cz/solutions/cockroach/DividendXlsxParser.kt
+++ b/src/main/kotlin/cz/solutions/cockroach/DividendXlsxParser.kt
@@ -19,7 +19,7 @@ object DividendXlsxParser {
         return file.inputStream().use { parse(it) }
     }
 
-    private val IGNORED_DESCRIPTIONS = listOf("TREASURY LIQUIDITY FUND", "WIRE OUT")
+    private val IGNORED_DESCRIPTIONS = listOf("TREASURY LIQUIDITY FUND", "WIRE OUT", "DIVIDEND REINVESTMENT")
 
     fun parse(inputStream: InputStream): DividendXlsxResult {
         val dividends = mutableListOf<DividendRecord>()


### PR DESCRIPTION
The reinvestments in e-trade otherwise show up as a negative line in the dividends list.