### PR TITLE
Fix dividend tax records reused across multiple dividends on same date

### DIFF
--- a/src/main/kotlin/cz/solutions/cockroach/DividentReportPreparation.kt
+++ b/src/main/kotlin/cz/solutions/cockroach/DividentReportPreparation.kt
@@ -21,7 +21,8 @@ object DividentReportPreparation {
 
         val taxRecords = taxRecordList
             .filter { interval.contains(it.date) }
-            .groupBy { it.date }
+            .groupBy({ it.date }) { it }
+            .mapValues { it.value.toMutableList() }
 
         val taxReversalRecords = taxReversalRecordList
             .filter { interval.contains(it.date) }
@@ -36,7 +37,9 @@ object DividentReportPreparation {
 
         for (dividendRecord in dividendRecords) {
             val exchange = exchangeRateProvider.rateAt(dividendRecord.date)
-            val taxRecord = taxRecords[dividendRecord.date]?.minBy { abs( abs(it.amount) - abs(dividendRecord.amount)*0.15 )} //if there were more taxes on the same day, we take the one closest to 15% of dividend amount, because that's the most likely correct one
+            val taxCandidates = taxRecords[dividendRecord.date]
+            val taxRecord = taxCandidates?.minByOrNull { abs( abs(it.amount) - abs(dividendRecord.amount)*0.15 )} //if there were more taxes on the same day, we take the one closest to 15% of dividend amount, because that's the most likely correct one
+            if (taxRecord != null) taxCandidates.remove(taxRecord)
 
             if (taxRecord != null) {
                 totalBruttoDollar += dividendRecord.amount

--- a/src/test/kotlin/cz/solutions/cockroach/DividentReportPreparationTest.kt
+++ b/src/test/kotlin/cz/solutions/cockroach/DividentReportPreparationTest.kt
@@ -1,0 +1,72 @@
+package cz.solutions.cockroach
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.joda.time.LocalDate
+import org.junit.jupiter.api.Test
+
+class DividentReportPreparationTest {
+
+    private val fixedRate = ExchangeRateProvider { 25.0 }
+    private val year2025 = DateInterval.year(2025)
+
+    @Test
+    fun taxRecordIsNotReusedWhenMultipleDividendsOnSameDate() {
+        // Schwab: large dividend with 30% withholding
+        // E-Trade: small dividend with 15% withholding
+        // Both on the same date - simulates the real bug
+        val dividends = listOf(
+            DividendRecord(LocalDate(2025, 10, 22), 1426.80),  // Schwab
+            DividendRecord(LocalDate(2025, 10, 22), 59.04)     // E-Trade
+        )
+        val taxes = listOf(
+            TaxRecord(LocalDate(2025, 10, 22), -428.04),  // Schwab (30% of 1426.80)
+            TaxRecord(LocalDate(2025, 10, 22), -8.86)     // E-Trade (15% of 59.04)
+        )
+
+        val report = DividentReportPreparation.generateDividendReport(
+            dividends, taxes, emptyList(), year2025, fixedRate
+        )
+
+        // Both dividends should be matched
+        assertThat(report.printableDividendList).hasSize(2)
+
+        // The total tax should include BOTH tax records, not -8.86 twice
+        assertThat(report.totalTaxDollar).isCloseTo(-436.90, Offset.offset(0.01))
+
+        // Each tax should be used exactly once
+        assertThat(report.totalTaxCrown).isCloseTo(-436.90 * 25.0, Offset.offset(0.1))
+    }
+
+    @Test
+    fun singleDividendWithSingleTaxOnSameDate() {
+        val dividends = listOf(DividendRecord(LocalDate(2025, 1, 22), 1000.0))
+        val taxes = listOf(TaxRecord(LocalDate(2025, 1, 22), -150.0))
+
+        val report = DividentReportPreparation.generateDividendReport(
+            dividends, taxes, emptyList(), year2025, fixedRate
+        )
+
+        assertThat(report.printableDividendList).hasSize(1)
+        assertThat(report.totalTaxDollar).isCloseTo(-150.0, Offset.offset(0.01))
+    }
+
+    @Test
+    fun dividendsOnDifferentDatesMatchCorrectTax() {
+        val dividends = listOf(
+            DividendRecord(LocalDate(2025, 1, 22), 1000.0),
+            DividendRecord(LocalDate(2025, 4, 23), 1200.0)
+        )
+        val taxes = listOf(
+            TaxRecord(LocalDate(2025, 1, 22), -150.0),
+            TaxRecord(LocalDate(2025, 4, 23), -180.0)
+        )
+
+        val report = DividentReportPreparation.generateDividendReport(
+            dividends, taxes, emptyList(), year2025, fixedRate
+        )
+
+        assertThat(report.printableDividendList).hasSize(2)
+        assertThat(report.totalTaxDollar).isCloseTo(-330.0, Offset.offset(0.01))
+    }
+}


### PR DESCRIPTION
## Summary
- Fix bug where the same tax withholding record could be matched to multiple dividend records when they share the same date (e.g. Schwab and E-Trade dividends both on 10/22)
- The 15%-heuristic `minBy` selection never removed used tax records from the candidate pool, causing one tax to be counted twice and another to be lost entirely
- In practice this understated the foreign tax paid from ~$437 to ~$18 for the 10/22/2025 dividend date

## Test plan
- [x] Added `DividentReportPreparationTest` with 3 test cases covering the bug scenario, single match, and multi-date matching
- [x] All 23 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)